### PR TITLE
Add configuration of property items

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,37 +34,78 @@
             "type": "object",
             "title": "multi-command",
             "properties": {
-                "multiCommand.commands": {
-                    "type": [
-                        "array",
-                        "object"
-                    ],
-                    "items": {
-                        "type": "object",
-                        "title": "command sequence",
-                        "properties": {
-                            "command": {
-                                "type": "string",
-                                "description": "command name of this command sequence"
-                            },
-                            "interval": {
-                                "type": "number",
-                                "description": "time interval(milliseconds) between each command execution."
-                            },
-                            "sequence": {
-                                "type": "array",
-                                "items": {
-                                    "type": [
-                                        "string",
-                                        "object"
-                                    ],
-                                    "description": "command sequence which been invoked"
-                                }
-                            }
-                        }
-                    },
-                    "description": "command sequence list."
-                }
+				"multiCommand.commands": {
+					"type": [
+						"array",
+						"object"
+					],
+					"description": "Command sequence list.",
+					"items": {
+						"type": "object",
+						"title": "Command sequence.",
+						"properties": {
+							"command": {
+								"type": "string",
+								"description": "Command name of this command sequence."
+							},
+							"interval": {
+								"type": "number",
+								"description": "Time interval (milliseconds) between each command execution."
+							},
+							"sequence": {
+								"type": "array",
+								"description": "Command sequence which been invoked.",
+								"items": {
+									"type": [
+										"string",
+										"object"
+									],
+									"properties": {
+										"command": {
+											"type": "string",
+											"description": "Command ID provided by VS Code or extensions."
+										},
+										"args": {
+											"type": "object",
+											"description": "Arguments of command."
+										},
+										"onSuccess": {
+											"type": "array",
+											"description": "Excuted when the previous command ends with a success."
+										},
+										"onFail": {
+											"type": "array",
+											"description": "Excuted when the previous command ends with an error."
+										},
+										"variableSubstitution": {
+											"type": "boolean",
+											"description": "Set to true if you want to use variable substitution starting with $ in args.",
+											"enum": [true, false],
+											"default": false
+										},
+										"repeat": {
+											"type": "number",
+											"description": "Number of times command is repeated.",
+											"default": 1
+										}
+									}
+								}
+							},
+							"languages": {
+								"type": "array",
+								"description": "Only visible in the command palette when a document in the specified language is opened. If not specified, it applies to all languages."
+							},
+							"label": {
+								"type": "string",
+								"description": "Label displayed in command palette when calling command sequence manually."
+							},
+							"description": {
+								"type": "string",
+								"description": "Description displayed in command palette when calling command sequence manually. (dimmed)"
+							}
+						}
+					}
+				}
             }
         }
     },

--- a/package.json
+++ b/package.json
@@ -34,78 +34,78 @@
             "type": "object",
             "title": "multi-command",
             "properties": {
-				"multiCommand.commands": {
-					"type": [
-						"array",
-						"object"
-					],
-					"description": "Command sequence list.",
-					"items": {
-						"type": "object",
-						"title": "Command sequence.",
-						"properties": {
-							"command": {
-								"type": "string",
-								"description": "Command name of this command sequence."
-							},
-							"interval": {
-								"type": "number",
-								"description": "Time interval (milliseconds) between each command execution."
-							},
-							"sequence": {
-								"type": "array",
-								"description": "Command sequence which been invoked.",
-								"items": {
-									"type": [
-										"string",
-										"object"
-									],
-									"properties": {
-										"command": {
-											"type": "string",
-											"description": "Command ID provided by VS Code or extensions."
-										},
-										"args": {
-											"type": "object",
-											"description": "Arguments of command."
-										},
-										"onSuccess": {
-											"type": "array",
-											"description": "Excuted when the previous command ends with a success."
-										},
-										"onFail": {
-											"type": "array",
-											"description": "Excuted when the previous command ends with an error."
-										},
-										"variableSubstitution": {
-											"type": "boolean",
-											"description": "Set to true if you want to use variable substitution starting with $ in args.",
-											"enum": [true, false],
-											"default": false
-										},
-										"repeat": {
-											"type": "number",
-											"description": "Number of times command is repeated.",
-											"default": 1
-										}
-									}
-								}
-							},
-							"languages": {
-								"type": "array",
-								"description": "Only visible in the command palette when a document in the specified language is opened. If not specified, it applies to all languages."
-							},
-							"label": {
-								"type": "string",
-								"description": "Label displayed in command palette when calling command sequence manually."
-							},
-							"description": {
-								"type": "string",
-								"description": "Description displayed in command palette when calling command sequence manually. (dimmed)"
-							}
-						}
-					}
-				}
+                "multiCommand.commands": {
+                    "type": [
+                        "array",
+                        "object"
+                    ],
+                    "description": "Command sequence list.",
+                    "items": {
+                        "type": "object",
+                        "title": "Command sequence.",
+                        "properties": {
+                            "command": {
+                                "type": "string",
+                                "description": "Command name of this command sequence."
+                            },
+                            "interval": {
+                                "type": "number",
+                                "description": "Time interval (milliseconds) between each command execution."
+                            },
+                            "sequence": {
+                                "type": "array",
+                                "description": "Command sequence which been invoked.",
+                                "items": {
+                                    "type": [
+                                        "string",
+                                        "object"
+                                    ],
+                                    "properties": {
+                                        "command": {
+                                            "type": "string",
+                                            "description": "Command ID provided by VS Code or extensions."
+                                        },
+                                        "args": {
+                                            "type": "object",
+                                            "description": "Arguments of command."
+                                        },
+                                        "onSuccess": {
+                                            "type": "array",
+                                            "description": "Excuted when the previous command ends with a success."
+                                        },
+                                        "onFail": {
+                                            "type": "array",
+                                            "description": "Excuted when the previous command ends with an error."
+                                        },
+                                        "variableSubstitution": {
+                                            "type": "boolean",
+                                            "description": "Set to true if you want to use variable substitution starting with $ in args.",
+                                            "enum": [true, false],
+                                            "default": false
+                                        },
+                                        "repeat": {
+                                            "type": "number",
+                                            "description": "Number of times command is repeated.",
+                                            "default": 1
+                                        }
+                                    }
+                                }
+                            },
+                            "languages": {
+                                "type": "array",
+                                "description": "Only visible in the command palette when a document in the specified language is opened. If not specified, it applies to all languages."
+                            },
+                            "label": {
+                                "type": "string",
+                                "description": "Label displayed in command palette when calling command sequence manually."
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": "Description displayed in command palette when calling command sequence manually. (dimmed)"
+                            }
+                        }
+                    }
+                }
             }
         }
     },


### PR DESCRIPTION
The property list does not currently contain the following items:

- property items in the sequence
    - `command`
    - `args`
    - `onSuccess`
    - `onFail`
    - `variableSubstitution`
    - `repeat`
- `languages`
- `label`
- `description`

Added these. These additions are useful because they help prevent typos by displaying suggestions when configuring settings.