### PR TITLE
docs: add tip on how to find available command ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,3 +328,9 @@ With Command Runner extension, you can write a command sequence with shell comma
 ```
 
 See the [Command Runner document](https://marketplace.visualstudio.com/items?itemName=edonet.vscode-command-runner) for details on how to use the extension.
+
+### Find all available command ids
+
+> Note: You can review the full set of VS Code commands via the Keyboard Shortcuts editor File > Preferences > Keyboard Shortcuts (on macOS Code > Preferences > Keyboard Shortcuts). The Keyboard Shortcuts editor lists all commands built into VS Code or contributed by extensions, along with their keybindings and visibility when clauses.
+
+From: https://code.visualstudio.com/api/references/commands

--- a/README.md
+++ b/README.md
@@ -333,4 +333,6 @@ See the [Command Runner document](https://marketplace.visualstudio.com/items?ite
 
 > Note: You can review the full set of VS Code commands via the Keyboard Shortcuts editor File > Preferences > Keyboard Shortcuts (on macOS Code > Preferences > Keyboard Shortcuts). The Keyboard Shortcuts editor lists all commands built into VS Code or contributed by extensions, along with their keybindings and visibility when clauses.
 
+To get the command's ID right click the command in the list > `Copy Command ID`
+
 From: https://code.visualstudio.com/api/references/commands


### PR DESCRIPTION
Thanks a lot for this amazing extension, exactly what I was looking for 🥳

I might've overlooked it, but I had to search to know how to find available command ids I could use in my sequence so I thought it'd be nice to add to the readme.

What do you think?